### PR TITLE
Include JQuery in a protocol-agnostic way

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 	<title>Labelauty jQuery Plugin</title>
 	<link rel="shortcut icon" href="assets/images/favicon.png">
 
-	<script type="text/javascript" src="http://code.jquery.com/jquery-latest.min.js"></script>
+	<script type="text/javascript" src="//code.jquery.com/jquery-latest.min.js"></script>
 	<script type="text/javascript" src="assets/scripts/jquery-labelauty.js"></script>
 
 	<link rel="stylesheet" href="assets/styles/jquery-labelauty.css" type="text/css" media="screen" charset="utf-8" />


### PR DESCRIPTION
Firefox does not load JQuery on https://fntneves.github.io/jquery-labelauty/
