### PR TITLE
Fix bug in example

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -13,12 +13,12 @@
 			<input checked type="checkbox" aria-label="Should this synchronize your files?" data-labelauty="Don't synchronize files|Synchronize my files"/>
 			<input type="checkbox" data-labelauty="Don't delete my files|Delete my files"/>
 			<input checked type="checkbox"/>
-			
-			<input checked type="radio" aria-label="Should this synchronize your files?" data-labelauty="Don't synchronize files|Synchronize my files"/>
-			<input type="radio" data-labelauty="Don't delete my files|Delete my files"/>
-			<input checked type="radio"/>
+
+			<input checked type="radio" name="radio-input" aria-label="Should this synchronize your files?" data-labelauty="Don't synchronize files|Synchronize my files"/>
+			<input type="radio" name="radio-input" data-labelauty="Don't delete my files|Delete my files"/>
+			<input checked type="radio" name="radio-input"/>
 		</form>
-		
+
 		<h2 tabindex="0">End of Example</h2>
 		<script>
 			$(document).ready(function(){


### PR DESCRIPTION
Radio buttons do not work unless they have the same `name` attribute. The example code treats the radio buttons like checkboxes.